### PR TITLE
docs: restructure documentation and rebrand to vanilla-rag-lab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to `.env` and fill in real values.
+# `.env` is gitignored and will NOT be present in a fresh clone — recreate it here.
+
+# Port the Express server listens on (defaults to 3000 if unset)
+PORT=3000
+
+# Ollama Cloud API key — used by rag-query-service.js for chat completions
+OLLAMA_API_KEY=
+
+# LanceDB API key (cloud vector store, if used)
+LancdbAPIKey=
+
+# Hugging Face API token
+HF_API_TOKEN=

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: "bug: "
+labels: ["bug"]
+assignees: ''
+---
+
+## Description
+
+_What's happening?_
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behaviour
+
+_What should happen?_
+
+## Actual Behaviour
+
+_What happens instead?_
+
+## Files Affected
+
+- 
+
+## Root Cause (if known)
+
+_Any analysis of why this is happening._
+
+## Screenshots
+
+_If applicable._

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,31 @@
+---
+name: Feature / Story
+about: A new feature or development story
+title: "feat: "
+labels: ["feature"]
+assignees: ''
+---
+
+## Context
+
+_Why is this needed? Link to any prior stories or discussions._
+
+## Acceptance Criteria
+
+- [ ] _Criterion 1_
+- [ ] _Criterion 2_
+- [ ] _Criterion 3_
+
+## Files Affected
+
+_List the files expected to be created or modified._
+
+**New:**
+- 
+
+**Modified:**
+- 
+
+## Notes
+
+_Architecture decisions, constraints, or references._

--- a/.github/ISSUE_TEMPLATE/tech-debt.md
+++ b/.github/ISSUE_TEMPLATE/tech-debt.md
@@ -1,0 +1,29 @@
+---
+name: Tech Debt
+about: Code quality, refactoring, or architectural improvements
+title: "chore: "
+labels: ["tech-debt"]
+assignees: ''
+---
+
+## Context
+
+_What triggered this? Link to the story or bug where it was identified._
+
+## Problem
+
+_What's wrong with the current approach?_
+
+## Scope
+
+- [ ] _Task 1_
+- [ ] _Task 2_
+- [ ] _Task 3_
+
+## Files Affected
+
+- 
+
+## Priority
+
+_Low / Medium / High — and why._

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,13 @@ vite.config.ts.timestamp-*
 # IDE
 .idea
 
+# macOS
+.DS_Store
+**/.DS_Store
+.AppleDouble
+.LSOverride
+._*
+
 # Misc
 /uploads
 /data

--- a/DataStructures.md
+++ b/DataStructures.md
@@ -1,0 +1,117 @@
+# Data structures
+synchronous vs asynchronous calls (and promises in javascript)
+disk vs sqlite database
+// Ask about sqlite persisting vs disk
+what do we define __direnam with __
+why doesnt export default collectionRoutes; work in routers
+BUG: When you create a new collection it will display whatever the previous collections files are
+
+- Should get collection stats live in the Rag Client module? and subsequent modules.
+- Create relevant javascript google docs to note high level learnings.
+- Should we rename ui-orchestrator? to bootstrap?
+- 
+
+
+// Coordinates the full pipeline for converting a document into searchable vectors:
+//
+//   PDF on disk → extract text → chunk → embed → store
+//
+// This module doesn't know HOW any of those steps work — it just calls each service in order and passes data
+// between them. If we swap LanceDB for Qdrant or Ollama for Gemini, this file doesn't change.
+// services/embedding-pipeline.js
+//
+// Orchestrates the full document embedding pipeline:
+//   1. Look up the document in SQLite
+//   2. Extract text from the PDF
+//   3. Split text into overlapping chunks
+//   4. Generate embeddings via Ollama
+//   5. Store chunks in SQLite (metadata) + LanceDB (vectors)
+//
+// Each step is handled by a dedicated module — this file only
+// coordinates the flow and manages the database transaction.
+
+
+// service -rag-servie
+// Handles RAG stats queries and the full RAG query flow:
+//   1. Embed the user's question using the same model that embedded the documents
+//   2. Vector search in LanceDB scoped to the active collection
+//   3. Build a prompt with retrieved context chunks
+//   4. Call Ollama Cloud's chat completion endpoint
+//   5. Return the generated answer + source references
+//
+// The embedding model (nomic-embed-text) runs locally via Ollama.
+// The chat model runs on Ollama Cloud — requires OLLAMA_API_KEY in .env
+
+
+// ── Ollama Cloud client (lazy) ──────────────────────────
+// Created on first use so process.env is populated by the time
+// the client reads OLLAMA_API_KEY. ES module imports are hoisted
+// and evaluated before top-level code (like dotenv.config()) runs,
+// so constructing the client at module load time would capture
+// undefined env vars.
+
+https://fonts.google.com/icons
+- https://fontawesome.com/
+- https://lucide.dev/
+- https://getbootstrap.com/
+- https://heroicons.com/
+- https://simpleicons.org/
+
+
+- https://htmlreference.io/
+- https://cssreference.io/
+
+## Collection
+```Collection
+{ 
+    id: "uuid" [PK]
+    name: "Research Papers"
+    "createdAt": "2026-02-13T...",
+    "updatedAt": "2026-02-13T..."
+}
+```
+Add icon: future enhancement
+
+## Document
+```Document
+{
+    id: "uuid" [PK]
+    collection_id: "uuid" [FK]
+    fileName(change to filename): "a]b2c3_file.pdf",
+    "originalName": "My Research Paper.pdf",
+    "size": 1048576,
+    "mimeType": "application/pdf",
+    "createdAt": "2026-02-13T..."
+}
+```
+
+Bugs
+WHen uploading Bert.pdf 16 pages I get the following error:
+
+Warning: UnknownErrorException: Ensure that the `standardFontDataUrl` API parameter is provided.
+Embedding pipeline failed: TypeError: fetch failed
+at node:internal/deps/undici/undici:13510:13
+at async embedBatch (file:///Users/maxpike/Workspace/vanilla-ai-lab/services/embedding-service.js:37:22)
+at async embedDocument (file:///Users/maxpike/Workspace/vanilla-ai-lab/services/embedding-pipeline.js:41:21)
+at async file:///Users/maxpike/Workspace/vanilla-ai-lab/routes/embedding-routes.js:14:24 {
+[cause]: HeadersTimeoutError: Headers Timeout Error
+at FastTimer.onParserTimeout [as _onTimeout] (node:internal/deps/undici/undici:6249:32)
+at Timeout.onTick [as _onTimeout] (node:internal/deps/undici/undici:2210:17)
+at listOnTimeout (node:internal/timers:588:17)
+at process.processTimers (node:internal/timers:523:7) {
+code: 'UND_ERR_HEADERS_TIMEOUT'
+}
+}
+
+[Log] orchestrator initialised and modules linked. (ui-orchestrator.js, line 20)
+> Selected Element
+< <main class="main-content">…</main>
+[Error] Failed to load resource: the server responded with a status of 500 (Internal Server Error) (fb7a6230-3192-470a-a9ff-df77e58b8e2f, line 0)
+[Error] embedding-client error:
+Error: Internal server error
+(anonymous function) — embedding-client.js:15
+(anonymous function) (embedding-client.js:16)
+[Error] Embed failed:
+Error: Internal server error
+(anonymous function) — embedding-client.js:15
+(anonymous function) (sidebar-right.js:251)

--- a/MODULES.md
+++ b/MODULES.md
@@ -1,0 +1,270 @@
+# Modules
+
+## Entry Points
+
+### server.js
+The HTTP server bootstrap. Its only job is to import the configured Express app from `app.js`, bind it to a port, and
+start listening. The port is read from `process.env.PORT` (set via `.env` / `config/env.js`) and falls back to `3000`.
+
+This file is intentionally minimal - its owns *only* the `listen()` call, keeping the Express configuration testable 
+in isolation via `app.js`
+
+### app.js
+The application's configuration hub. Responsible for:
+
+- **Environment & database initialisation** - Imports `config/env.js` (which loads `.env` via dotenv) and `db/database.js`
+    (which runs SQLite migrations) as side-effect imports. These run first because ES module import order is deterministic
+    — they execute top-to-bottom before any application code.
+- **Express setup** - Creates and exports the Express instance so `server.js` (and test harnesses) can import it without 
+    triggering `listen()`.
+- **Middleware** - Applies CORS (cross-origin requests), JSON body parsing, and static file serving from `public/`.
+- **Route mounting** - Connects each API namespace to its route module under `/api/*`.
+
+The exported `app` object is the boundary between "configuration" and "runtime" - everything above `listen()` lives here, 
+and `server.js` handles the rest.
+
+---
+
+## Public — Client Modules
+
+The `public/js/` directory contains all frontend code, split into two layers: **clients** (networking) and **UI** 
+(DOM interaction). This separation means UI modules never construct URLs or call `fetch()` directly, and client modules 
+never touch the DOM.
+
+### Client Layer — Shared Pattern
+
+All client modules follow the same structural pattern:
+
+1. **Base URL constant** — Each client defines a `BASE` path (e.g., `"/api/collections"`) so route URLs are defined in  
+one place.
+2. **Two-tier error handling** — Every method uses a `try/catch` around the `fetch()` call to catch *network* errors 
+(server unreachable, DNS failure), then checks `res.ok` to catch *HTTP* errors (400s, 500s). This distinction matters: a
+network error means the request never reached the server, while an HTTP error means the server responded with a problem.
+3. **Error message isolation** — On HTTP errors, the client reads the response body for an error message but wraps it in
+a *new* `Error`. This prevents raw backend error details (stack traces, SQL errors) from leaking to the UI layer or the user.
+4. **No DOM knowledge** — Clients return data or throw errors. They never reference `document`, elements, or any rendering
+logic.
+
+This pattern is consistent across all client modules below, so individual descriptions focus on what makes each module 
+unique rather than repeating the shared structure.
+
+### api-client.js
+A minimal client with a single `fetchHello()` function used during initial project scaffolding to verify the frontend-to
+-backend connection. Calls `GET /api/hello` and returns the JSON response. Unlike other clients, it uses a hardcoded 
+absolute URL (`http://localhost:3000/api/hello`) rather than a relative `BASE` path — a leftover from Story 1 scaffolding.
+
+### collection-client.js
+CRUD operations for collections:
+
+- `createCollection(name)` — `POST /api/collections` with a JSON body.
+- `fetchCollections()` — `GET /api/collections`.
+- `updateCollection(name, id)` — `PUT /api/collections/:id` to rename a collection.
+- `deleteCollection(id)` — `DELETE /api/collections/:id`. No return value on success (void).
+
+### document-client.js
+Manages documents within collections. Includes client-side validation before the request is sent:
+
+- `fetchDocuments(collectionId)` — `GET /api/documents/:collectionId`
+- `fetchDocumentsWithEmbedStatus(collectionId)` — `GET /api/documents/:collectionId/embed-status`   
+  - Returns documents annotated with whether they have been embedded into the vector store, allowing the UI to show embedding state.
+- `uploadDocuments(files, collectionId)` — `POST /api/documents/:collectionId/upload`.  
+  - Performs two validations before sending: rejects if no files are selected, and checks each file against a `MAX_FILE_SIZE` of 10MB.
+  Sends files as `FormData` (multipart), not JSON. Currently limited to 10 files per upload (both limits are practical constraints to be revisited).
+- `deleteDocument(id)` — `DELETE /api/documents/:id`  
+  - Removes the document from its collection. No return value on success.
+
+### embedding-client.js
+Single-purpose client for triggering the embedding pipeline:
+
+- `embedDocument(documentId)` — `POST /api/embeddings/:documentId`
+  - Kicks off the server-side pipeline that extracts text, chunks it, generates embeddings via Ollama, and stores vectors
+  in LanceDB. Returns `{ documentId, chunksCreated, dimensions }` on success.
+
+### rag-client.js
+Interfaces with the RAG query pipeline:
+
+- `getCollectionStats(collectionId)` — `GET /api/rag/stats/:collectionId`  
+  - Returns document count, chunk count, and embedding count for the selected collection. Used by the UI to show collection readiness.
+- `queryRag(query, collectionId)` — `POST /api/rag/query` with JSON body `{ query, collectionId }`
+  - Sends the user's question to the RAG pipeline, which embeds the query, performs semantic search, builds a prompt with retrieved 
+  context, and returns `{ answer, sources }` where sources include document names and relevant excerpts.
+
+
+## Public — UI Layer
+
+### ui-orchestrator.js
+The frontend's bootstrap module. When the browser loads `index.html`, this is the entry point that wires everything together. It:
+
+- **Imports and initialises all page modules** — `router.js`, `sidebar-left.js`, `sidebar-right.js`, `collections-page.js`, and 
+`rag-page.js` are imported as side-effect modules, meaning their top-level code (DOM queries, event listeners) runs on import.
+- **Wires up the hello-world demo** — Attaches a click handler on `#helloBtn` that delegates to `fetchHello()` from `api-client.js`
+(Story 1 scaffolding).
+
+Despite its name suggesting orchestration, this module currently acts more as a **module bootstrapper** — it ensures all page 
+modules are loaded and initialised. The actual UI logic (rendering, event handling, state) lives in the individual page modules
+it imports.
+
+---
+
+## Services
+The `services/` directory contains all backend business logic. Services have zero knowledge of HTTP - they never read request 
+objects or write response objects. They receive plain arguments (strings, objects) and return data or throw errors. Routes are
+the thin adapter layer that translates HTTP into service calls.
+
+Services interact with two data stores: **SQLite** (via `better-sqlite3`) for structure metadata and **LanceDB** for vector 
+storage. Most services pre-compile their SQL statements as module-level constants using `db.prepare()`, which means the 
+statements are  parsed once at startup and reused on every call -  a performance pattern specific to `better-sqlite3`.
+
+### Service Layer — Data Flow
+The services form a pipeline that processes documents from upload through to queryable RAG:
+
+```
+Upload → Store metadata (document-service)
+       → Extract text (pdf-extractor)
+       → Split into chunks (chunker)
+       → Generate embeddings (embedding-service)
+       → Store vectors (vector-store)
+       → Query: embed question → search vectors → build prompt → LLM answer (rag-query-service / rag-service)
+```
+
+Each step in the pipeline is a standalone module with a single responsibility. The `embedding-pipeline.js` orchestrates
+the middle steps (extract → chunk → embed → store), while `rag-query-service.js` orchestrates the query path.
+
+### collection-service.js
+CRUD operations for collections. Each collection maps to both a SQLite row and a filesystem directory under `uploads/`:
+
+- `addCollection(name)` — Generates a UUID, inserts a row into `collections`, and creates the upload directory. Returns `{ id, name }`.
+- `listCollection()` — Returns all collections with a `doc_count` computed via a `LEFT JOIN` on `documents`. This lets the UI show 
+document counts without a separate query.
+- `updateCollection(name, id)` — Renames a collection and touches `updated_at`.
+- `deleteCollection(id)` — Deletes the SQLite row (which cascades to documents and chunks via foreign keys), removes the upload 
+directory from disk, and cleans up associated vectors from LanceDB.
+
+The delete operation is `async` because the LanceDB cleanup (`deleteByCollection`) is asynchronous, while the SQLite and 
+filesystem operations are synchronous.
+
+### document-service.js
+Manages document metadata and file storage within collections:
+
+- `storeDocument(file, collectionId)` — Receives a multer file object, generates a UUID, moves the temp file to the collection's 
+upload directory (renamed as `{uuid}_{originalname}`), and inserts metadata into SQLite. Returns a full document descriptor with 
+id, collectionId, fileName, originalName, size, and mimeType.
+- `listDocuments(collectionId)` — Returns all documents in a collection.
+- `listDocumentsWithEmbedStatus(collectionId)` — Extends the basic listing with a `chunk_count` computed via a `LEFT JOIN` on 
+- `chunks`. A `chunk_count` of 0 means the document has not been embedded; greater than 0 means it is queryable.
+- `deleteDocument(id)` — Looks up the document, removes the file from disk (`unlinkSync`), deletes the SQLite row, and cleans 
+up vectors from LanceDB. Returns silently if the document doesn't exist.
+
+The file naming convention (`{uuid}_{originalname}`) prevents collisions while preserving the original name for display purposes.
+
+### pdf-extractor.js
+Single-purpose module that extracts text from PDF files on disk:
+
+- `extractText(collectionId, fileName)` — Uses `pdfjs-dist` (Mozilla's PDF.js, legacy build for Node.js compatibility) to open 
+the PDF, iterate through each page, and concatenate all text content. Respects end-of-line markers from the PDF structure (`item.hasEOL`)
+to preserve paragraph boundaries. Pages are joined with double newlines, which the chunker later uses as its primary split point.
+
+### chunker.js
+Splits extracted text into overlapping chunks suitable for embedding. This is a pure function module with no I/O or database 
+dependencies — it takes a string and returns chunk objects.
+
+- `chunkText(text, opts)` — The public entry point. Accepts configurable `chunkSize` (default 500 characters) and `chunkOverlap` 
+- (default 50 characters). Returns an array of `{ content, tokenEstimate }` objects.
+
+The chunking algorithm works in two phases:
+1. **Recursive splitting** (`recursiveSplit`) — Tries progressively finer separators: paragraph breaks (`\n\n`), line breaks (`\n`),
+sentence endings (`. `, `! `, `? `), commas, then spaces. If text exceeds `chunkSize`, it splits on the coarsest available separator
+and recurses on any pieces that are still too large, using the next-finer separator. This preserves semantic boundaries — paragraphs
+stay together when possible, then sentences, then words.
+2. **Merge with overlap** (`mergeWithOverlap`) — Reassembles small fragments into chunks up to `chunkSize`, then prepends 
+`chunkOverlap` characters from the previous chunk to each subsequent chunk. The overlap ensures that information spanning a chunk 
+boundary appears in at least one complete chunk, preventing context loss during retrieval.
+
+The `tokenEstimate` uses a rough heuristic of 4 characters per token, which is a common approximation for English text.
+
+### embedding-service.js
+Interfaces with Ollama's embedding API using raw `fetch()` calls to the local Ollama instance:
+
+- `embed(text)` — Generates a single embedding vector (768 dimensions with `nomic-embed-text`). Calls `POST /api/embed` with the 
+text as input and returns the first vector from the response.
+- `embedBatch(texts)` — Generates embeddings for multiple texts in a single API call. Ollama's `/api/embed` endpoint accepts an 
+array as `input`, returning one vector per text in the same order. This avoids N round trips for N chunks.
+- `checkOllamaStatus(requiredModels)` — Health check that verifies Ollama is reachable and that all required models are installed.
+Calls `/api/tags` to list installed models, then checks against the required list. Returns a structured result with `available`,
+`models`, and `reason` fields. Handles the `:latest` tag convention where Ollama may store a model as `nomic-embed-text:latest`
+while you request `nomic-embed-text`.
+
+Note: This service talks to the *local* Ollama instance (`localhost:11434`) for embeddings, while `rag-query-service.js` uses the
+Ollama JS client for chat completions — two different connection patterns to Ollama.
+
+### embedding-pipeline.js
+The orchestrator that ties together the embedding workflow for a single document. This is where the individual service modules 
+are composed into a complete pipeline:
+
+- `embedDocument(documentId)` — Executes the full pipeline:
+    1. **Fetch metadata** from SQLite to get the file path.
+    2. **Check for re-embedding** — If chunks already exist for this document, deletes them first to allow clean re-processing.
+    3. **Extract text** via `pdf-extractor.js`.
+    4. **Chunk text** via `chunker.js`.
+    5. **Generate embeddings** via `embedding-service.js` (batch call).
+    6. **Store chunk metadata** in SQLite — Uses a `db.transaction()` to insert all chunks atomically, ensuring either all or none are persisted.
+    7. **Store vectors** in LanceDB via `vector-store.js`.
+
+Returns `{ documentId, chunksCreated, dimensions }` on success. Each step validates its output and throws descriptive errors on failure,
+so callers get clear feedback about where the pipeline broke.
+
+### vector-store.js
+
+Manages vector storage and retrieval via LanceDB:
+
+- `addVectors(rows)` — Inserts chunk vectors into the `chunks` table. Uses a try/catch pattern to either `openTable` (if it exists)
+and `add`, or `createTable` on first use. This means the LanceDB table is lazily created on the first embedding, with no explicit
+schema definition — LanceDB infers the schema from the first batch of records.
+- `search(queryVector, collectionId, limit)` — Performs nearest-neighbour vector search scoped to a collection. Calls LanceDB's
+`.search()` with a `.where()` filter on `collection_id` and returns results mapped to a clean object shape. The `score` field is
+LanceDB's `_distance` (L2 distance by default — lower is more similar).
+- `deleteByDocument(documentId)` — Removes all vectors for a document. Called during document deletion to prevent stale vectors
+from polluting search results.
+- `deleteByCollection(collectionId)` — Removes all vectors for a collection. Called during collection deletion.
+
+The database connection is lazily initialised via `getDb()` and cached in a module-level variable. LanceDB stores data on disk at `data/lancedb/` as an embedded database — no separate server process required.
+
+### rag-service.js
+
+Provides simple aggregate queries against SQLite for collection statistics:
+
+- `getDocumentCount(collectionId)` — Returns the number of documents in a collection.
+- `getChunkCount(collectionId)` — Returns the number of chunks across all documents in a collection (joins `chunks` through `documents`).
+
+These are used by the stats endpoint to show collection readiness in the UI.
+
+### rag-query-service.js
+
+Orchestrates the full RAG query flow — the read-side counterpart to `embedding-pipeline.js` (which handles the write side):
+
+- `queryRag(query, collectionId)` — Executes the complete query pipeline:
+    1. **Embed the query** using the same model (`nomic-embed-text`) that was used for documents, ensuring vectors are in
+    the same embedding space.
+    2. **Vector search** — Retrieves the top-K (default 5) most relevant chunks from LanceDB.
+    3. **Enrich with metadata** — Looks up document names from SQLite so the LLM can cite sources.
+    4. **Build prompt** — Constructs a system prompt that includes the retrieved context blocks, each labelled with a source
+    number and document name. The prompt instructs the LLM to answer only from the provided context and to cite sources by document name.
+    5. **Chat completion** — Sends the system prompt and user question to Ollama Cloud via the official JS client 
+    (`ollama` package). Uses a lazy-initialised client with API key authentication.
+    6. **Deduplicate sources** — Returns unique source documents with 120-character excerpts.
+
+This module uses a different Ollama connection than `embedding-service.js`: it connects to Ollama Cloud (remote, 
+authenticated via API key) for the chat model, while embeddings use the local Ollama instance. The chat model is configurable
+via `CHAT_MODEL` environment variable.
+
+---
+
+## Routes
+
+*To be documented in a subsequent pass.*
+
+---
+
+## Testing
+
+*To be documented in a subsequent pass.*

--- a/NEXT_ACTIONS.md
+++ b/NEXT_ACTIONS.md
@@ -1,0 +1,92 @@
+# Next Actions
+
+Working handoff for continuing this project on another machine. Last updated **2026-07-22**.
+
+**Context:** Mid-flight documentation overhaul and project rebrand (`vanilla-ai-lab` → `vanilla-rag-lab`).
+Task tracking is moving into [GitHub Issues](../../issues); the `.md` docs are becoming high-level narrative only.
+
+---
+
+## 0. Set up on the new laptop (do this first, right after cloning)
+
+`.env` is gitignored, so it is **not** in a fresh clone. You must recreate it.
+
+```bash
+git clone <repo-url>
+cd vanilla-rag-lab            # (repo may still be named vanilla-ai-lab until the rename lands)
+npm install
+cp .env.example .env         # then fill in real values (see table below)
+docker compose up -d         # starts Ollama + pulls models
+npm run dev                  # backend, port 3000
+npm run dev:sync             # (second terminal) frontend hot reload, port 3001
+```
+
+### Environment variables
+
+Copy the **real** secret values from the old laptop's `.env` — they are not stored in git.
+
+| Variable         | Purpose                                                        |
+|------------------|---------------------------------------------------------------|
+| `PORT`           | Express server port (defaults to `3000`)                      |
+| `OLLAMA_API_KEY` | Ollama Cloud auth for chat completions (`rag-query-service.js`) |
+| `LancdbAPIKey`   | LanceDB cloud key                                              |
+| `HF_API_TOKEN`   | Hugging Face API token                                         |
+
+---
+
+## 1. Finish the documentation overhaul (where you left off)
+
+- [ ] **`MODULES.md` → Routes section** — currently a `*To be documented in a subsequent pass*` stub. Document each file in `routes/`.
+- [ ] **`MODULES.md` → Testing section** — same stub; document the Jest setup, unit/integration split, and the extracted validators.
+- [ ] **`.github/BRANCHING-STRATEGY.md`** — currently a 0-byte empty file. Write up the Git Flow model (main / dev / feature branches, branch protection) that ROADMAP Phase 4 already references.
+- [ ] **`STORIES.md`** — retitled "historical - To Be Deleted". Migrate anything still useful into GitHub Issues, then delete the file.
+- [ ] **`DataStructures.md`** — resolve/clean the raw open questions appended at the top (see §2), then keep only the finalized data-structure notes.
+
+### Propagate the rebrand (`vanilla-ai-lab` → `vanilla-rag-lab`)
+
+- [ ] `package.json` is done. **`README.md` still titled "Vanilla AI Lab"** — update title/description.
+- [ ] Check `design.md` and any other doc for stale "AI Lab" references.
+- [ ] Repo/remote URL: `package.json` now points at `github.com/maximpike/vanilla-rag-lab`. Rename the GitHub repo (or revert) so the URL is valid before others clone.
+
+### Doc-vs-code consistency to reconcile
+
+- [ ] `README.md` says the chat model is `llama3.2` (local, via `docker compose`), but `rag-query-service.js` defaults `CHAT_MODEL` to `gpt-oss:20b-cloud` on **Ollama Cloud**. Pick one story and make README + code agree.
+
+---
+
+## 2. Open design questions (pulled from `DataStructures.md`)
+
+- Should `getCollectionStats` live in the RAG client module (and where do subsequent stats calls belong)?
+- Rename `ui-orchestrator.js` → `bootstrap.js`? (MODULES.md already notes it behaves as a module bootstrapper, not an orchestrator.)
+- Create JS/Google-docs notes capturing high-level learnings.
+- Bug noted: creating a new collection can display the *previous* collection's files until refresh.
+
+---
+
+## 3. Git housekeeping before you commit
+
+> ⚠️ **Your newest edits are NOT staged.** The MODULES.md expansion (~265 lines) and the entire
+> ROADMAP.md rewrite are unstaged. Committing "staged only" would commit the *old* 25-line MODULES.md
+> and **drop the ROADMAP rewrite**. Stage the working-tree changes before committing:
+
+```bash
+git add -A                                  # or add specific files below
+# newer edits currently unstaged:
+#   DataStructures.md  MODULES.md  ROADMAP.md  STORIES.md  package.json  services/rag-query-service.js
+# new files to include:
+git add NEXT_ACTIONS.md .env.example .gitignore
+```
+
+- `.DS_Store` is now gitignored (macOS section added). It was previously showing as untracked.
+- Confirm nothing sensitive is staged (the real `.env` stays ignored).
+
+---
+
+## 4. Roadmap pointers (Phase 5 — Stabilisation, current)
+
+Tracked in more detail in `ROADMAP.md`. Known items to verify during code review:
+
+- **Tech debt:** audit route parameter handling across all route files; store timestamps as UTC with a timezone indicator.
+- **Story 10 bugs:** collections-page row alignment; concurrent rename locking; sidebar↔page event sync on collection create; invalid date (double `Z` suffix) on collection creation.
+
+Next planned phase is **Phase 6 — Agentic component** (LangGraph.js ReAct agent over uploaded datasets).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,45 +1,137 @@
-# 🚀 Weekend Project: Vanilla JS RAG & Similarity Lab
+# Roadmap - Updated/To Be Reviewed
 
-## 🎯 Goal
-Build a modular, framework-free RAG system with a similarity graph visualization.
+## Overview
 
----
+vanilla-rag-lab is a full-stack RAG (Retrieval-Augmented Generation) system built with vanilla JavaScript, Express.js, and SQLite. This roadmap tracks what's been completed, what needs fixing, and what's planned.
 
-## 📅 Saturday: The Modular Backend (The "Engine")
-
-### Phase 1: Infrastructure & Data (9 AM - 12 PM)
-- [ ] Initialize `npm init` and install `express`, `dotenv`, and `cors`.
-- [ ] **Module - `data/db.js`**: Create a static JSON array of "knowledge snippets."
-- [ ] **Module - `services/vector-math.js`**: Implement the Cosine Similarity formula.
-- [ ] **Module - `services/embedding-service.js`**: Create a function to fetch embeddings from an API.
-
-### Phase 2: The RAG Logic (1 PM - 5 PM)
-- [ ] **Module - `rag-orchestrator.js`**: Create the main logic that:
-    1. Takes a user query.
-    2. Converts it to a vector.
-    3. Finds the top-N matches using your math module.
-    4. Formats a prompt for the LLM.
-- [ ] **Routes**: Create `POST /query` and `GET /graph-data` in `server.js`.
-
-### Phase 3: Validation (6 PM - 8 PM)
-- [ ] Use Postman or `curl` to verify the backend returns the correct "most similar" documents for a query.
+Detailed task tracking lives in [GitHub Issues](../../issues). This document provides the high-level narrative.
 
 ---
 
-## 📅 Sunday: The Modular Frontend (The "Body")
+## Phase 1: Foundation (Complete)
 
-### Phase 1: The Orchestrator (9 AM - 11 AM)
-- [ ] Set up `index.html` with `<script type="module" src="ui-orchestrator.js"></script>`.
-- [ ] **Module - `api-client.js`**: Write clean `async` wrappers for your backend endpoints.
+Core application scaffolding, layout, and navigation.
 
-### Phase 2: UI & Graph Rendering (12 PM - 4 PM)
-- [ ] **Module - `dom-utils.js`**: Write functions to render chat bubbles and source cards.
-- [ ] **Module - `graph-renderer.js`**:
-    - Initialize HTML5 Canvas.
-    - Write a function `drawNodes(data)` to map similarity scores to X/Y coordinates.
-    - Draw lines (edges) between nodes with high similarity.
+| Story | Summary                                        | Status |
+|-------|------------------------------------------------|--------|
+| 1     | Project scaffolding & dev environment          | Done   |
+| 2     | Three-panel layout & mint theme                | Done   |
+| 3     | Left sidebar collapse toggle                   | Done   |
+| 4     | Right sidebar collections system (local state) | Done   |
+| 8     | Client-side page routing                       | Done   |
+| 9     | Right sidebar collapse toggle                  | Done   |
 
-### Phase 3: Integration (5 PM - 8 PM)
-- [ ] Connect the search bar to the Orchestrator.
-- [ ] Trigger a graph re-render whenever new data is fetched.
-- [ ] **Refactor Challenge**: Ensure no file is longer than 100 lines. If it is, split it!
+---
+
+## Phase 2: Data Layer (Complete)
+
+Backend persistence, file management, and collection operations.
+
+| Story | Summary                                            | Status |
+|-------|----------------------------------------------------|--------|
+| 5     | SQLite database & collections persistence          | Done   |
+| 6     | File upload & document management                  | Done   |
+| 10    | Manage collections page (rename, delete, table UI) | Done   |
+| 11    | Document delete confirmation dialog                | Done   |
+
+---
+
+## Phase 3: RAG Pipeline (Complete)
+
+Document processing, embedding generation, vector storage, and chat interface.
+
+| Story  | Summary                                                              | Status |
+|--------|----------------------------------------------------------------------|--------|
+| 7      | Embedding pipeline (PDF extraction, chunking, Ollama, LanceDB)       | Done   |
+| 12     | RAG chat page UI (stats cards, message bubbles, input bar)           | Done   |
+| 13     | RAG query flow (embed query, vector search, LLM generation, sources) | Done   |
+
+---
+
+## Phase 4: Quality & CI (Complete)
+
+Testing infrastructure and deployment pipeline.
+
+| Item            | Summary                                                    | Status  |
+|-----------------|------------------------------------------------------------|---------|
+| Jest setup      | ES modules support with experimental VM modules            | Done    |
+| Unit tests      | Chunker test suite (20 tests)                              | Done    |
+| Validators      | Extracted pure validation functions for testability        | Done    |
+| GitHub Actions  | dev-ci.yml and production-ci.yml workflows                 | Done    |
+| Branch strategy | Git Flow with main/dev/feature branches, branch protection | Done    |
+
+---
+
+## Phase 5: Stabilisation (Current)
+
+Bug fixes, tech debt, code review, and workflow improvements.
+
+Tracked in GitHub Issues with labels: `bug`, `tech-debt`.
+
+**Known tech debt:**
+- TD-1: Audit route parameter handling across all route files
+- TD-2: Store timestamps as UTC with timezone indicator
+
+**Known bugs from Story 10:**
+- Collections page row alignment (name cell elevation)
+- Concurrent rename locking (multiple rows editable simultaneously)
+- Sidebar-to-page event sync (collection created in sidebar not reflected on page)
+- Invalid date on collection creation (double Z suffix)
+
+> These items may have been partially patched during development. Verification needed during code review sessions.
+
+---
+
+## Phase 6: Agentic Component (Planned)
+
+LangGraph.js agent for natural language dataset querying.
+
+**Scope:**
+- Dataset ingestion pipeline (CSV/JSON upload → SQLite tables)
+- LangGraph.js ReAct agent with SQL query and schema inspection tools
+- Conversation memory via LangGraph checkpointer
+- Agent chat UI (reuse RAG chat patterns)
+- Dataset inspector in right sidebar (schema, row preview)
+
+**Dependencies:** `@langchain/langgraph`, `@langchain/core`, `csv-parse`
+
+---
+
+## Phase 7: Enhancements (Planned)
+
+Feature ideas for future development. Each will become a GitHub Issue when ready.
+
+**RAG improvements:**
+- Advanced chunking strategies (semantic, sliding window, hierarchical)
+- Hybrid search (vector + BM25 keyword search)
+- Re-ranking pipeline (cross-encoder models)
+- Conversation memory within RAG chat sessions
+- Source attribution with inline citations linking to sidebar documents
+
+**UI:**
+- Similarity graph visualisation (HTML5 Canvas, pairwise cosine similarity)
+- Dark mode (CSS custom property extension)
+- Dashboard page with system metrics
+
+**Infrastructure:**
+- Multi-format document support (.txt, .md, .docx, .csv)
+- API key management for cloud models (Gemini, OpenAI)
+- GPU acceleration for embedding generation
+- Persistent configuration (user preferences across restarts)
+- Self-hosted vector database server for production
+- Model provider abstraction layer (swap Ollama/Gemini/OpenAI)
+
+---
+
+## Phase 8: Deployment (Planned)
+
+Production deployment strategy. Details TBD once application is stable.
+
+---
+
+## Version History
+
+| Version  | Phase     | Notes                         |
+|----------|-----------|-------------------------------|
+| 0.1.0    | Phase 1-3 | MVP with full RAG pipeline    |
+| 0.2.0    | Phase 4   | Testing and CI infrastructure |

--- a/STORIES.md
+++ b/STORIES.md
@@ -1,0 +1,205 @@
+# Stories - historical - To Be Deleted
+
+## Story 1: Project Scaffolding & Dev Environment
+**Commit:** Initial scaffolding
+
+- Express 5 server with static file serving (`public/`)
+- ES module configuration (`"type": "module"`)
+- CORS middleware
+- `npm run dev` with `--watch` for auto-restart
+- Frontend hello-world: `ui-orchestrator.js` → `api-client.js` → `GET /api/hello`
+- README, ROADMAP, LICENSE, .gitignore
+
+## Story 2: Three-Panel Layout & Theming
+**Commit:** feat: Add three-panel layout with mint theme and component CSS
+
+- Three-panel CSS Grid layout: left sidebar (260px), main content (flex), right sidebar (304px)
+- Mint theme via CSS custom properties (backgrounds, accents, text, borders, spacing, radii)
+- Component CSS files: `sidebar-left.css`, `sidebar-right.css`, `main-content.css`, `footer.css`
+- Left sidebar: logo/branding, nav links (Home, Dashboard, RAG Chat), settings + collapse footer
+- Right sidebar: header, upload button, document list structure
+- Collapsed sidebar CSS (visual rules only, JS toggle in later story)
+- Footer with status indicator and version display
+- CSS reset and base typography
+- JS files moved to `public/js/` directory
+
+## Story 3: Left Sidebar — Collapse Toggle
+**Commit:** feat: Add sidebar collapse toggle
+
+- `sidebar-left.js`: collapse button toggles `.collapsed` class on sidebar
+- CSS transition from Story 2 handles the animation
+- Imported as side-effect module in `ui-orchestrator.js`
+
+## Story 4: Right Sidebar — Collections System
+**Commit:** feat: Add collections system to right sidebar
+
+- Three-state right sidebar: empty state → create input → active collection
+- Collection creation with inline input, confirm/cancel buttons, Enter/Escape shortcuts
+- Collection selector displays active collection name and document count
+- Dropdown with collection switching, active item hidden, "New Collection" option
+- Outside-click dismissal for dropdown
+- Truncation on long collection names via `text-overflow: ellipsis`
+- CSS sibling combinators hide content when dropdown is open
+- Collections stored in local JS array (no backend persistence yet)
+- Removed `transition: all` from base button rule, cleaned `transform: none` overrides
+
+## Story 5: Backend Infrastructure & Collections Persistence
+**Commit:** feat: Add SQLite database and collections persistence
+
+- SQLite via `better-sqlite3` with WAL mode and foreign key enforcement
+- SQL migration file (`001-init.sql`) for collections and documents tables
+- `collection-service.js`: CRUD operations with UUID keys, disk directory management
+- `collection-routes.js`: REST endpoints with validation and generic error responses
+- `collection-client.js`: API wrappers with separated network/HTTP error handling
+- `sidebar-right.js` refactored from local array to backend API calls
+- `renderDropdown` uses `createElement`/`textContent` to prevent XSS injection
+- Collections survive page refreshes via `init()` fetch on load
+- Upload directories created per-collection in `uploads/<collection_id>/`
+
+## Story 6: File Upload & Document Management
+**Commit:** feat: Add file upload and document management
+
+- `document-service.js`: store, list, delete documents with SQLite + disk storage
+- `document-routes.js`: REST endpoints scoped by collection ID, multer middleware
+- `document-client.js`: API wrappers with separated network/HTTP error handling
+- Multi-file upload support (max 10 files, 10MB limit per file)
+- Files stored at `uploads/<collection_id>/<uuid>_originalname.pdf` (collision-safe)
+- Upload button triggers hidden file input, change event sends files to API
+- `refreshDocuments()` re-fetches and re-renders document list after upload/delete
+- Document count synced in collection selector and dropdown
+- Delete button with hover reveal per document item
+
+## Story 7: Document Embedding Pipeline
+**Commit:** feat: Add document embedding pipeline with PDF extraction, chunking, and vector storage
+
+- `pdf-extractor.js`: text extraction from PDFs via `pdfjs-dist` legacy build (Node.js compatible)
+- `chunker.js`: recursive text splitting with overlap (500 char chunks, 50 char overlap)
+- `embedding-service.js`: Ollama `nomic-embed-text` embeddings (768-d), single + batch, health check
+- `vector-store.js`: LanceDB wrapper for vector insert, similarity search, document/collection deletion
+- `embedding-pipeline.js`: orchestrates extract → chunk → embed → store with SQLite transaction
+- `embedding-routes.js`: `POST /:documentId` triggers pipeline, `POST /search/:collectionId` queries vectors
+- `model-routes.js`: `GET /ollama/status` health check, separated for future model integrations (Gemini)
+- SQL migration `002-chunks.sql`: chunks table with document FK, content, token estimate, index
+- `database.js` updated to run migrations sequentially from array
+- `server.js` mounts `/api/embeddings` and `/api/models` routes
+- New dependencies: `pdfjs-dist`, `@lancedb/lancedb`, `@lancedb/lancedb-darwin-x64`
+- Vector data stored at `data/lancedb/`, chunk metadata in SQLite
+- Re-embedding a document clears old chunks before reprocessing
+- Known gap: LanceDB vector cleanup not yet wired into document/collection delete services
+
+## Story 8: Client-Side Page Routing
+**Commit:** feat: Add client-side page routing between Home, Dashboard, and RAG
+
+- `data-page` attributes on nav links and `<section>` elements
+- `public/js/router.js` — show/hide page sections, toggle `active` class on nav
+- Refactor `main-content.css`: move layout properties (max-width, padding, margin) from `.main-content` to `.page-home` so each page owns its own layout
+- Three page shells: `page-home`, `page-dashboard` (placeholder), `page-rag`
+- Wire router into `ui-orchestrator.js`
+
+## Story 9: Right Sidebar Collapse
+**Commit:** feat: Add right sidebar collapse toggle
+
+- Collapse icon button in the sidebar-right header (top-right corner)
+- CSS collapsed state for `.sidebar-right` (mirror left sidebar pattern)
+- JS toggle in `sidebar-right.js`
+- Transition animation matching left sidebar (width 0.3s ease-in-out)
+
+## Story 10: Manage Collections Page
+**Commit:** feat: Add dedicated collections management page with rename and delete
+
+- New "Collections" page in main content (`data-page="collections"`)
+- Left sidebar nav link with `dataset` icon, ordered after Home
+- Table layout: name (with folder icon), document count, created date, actions
+- Inline rename: edit button → name cell becomes input with Enter/Escape/confirm/cancel
+- Delete with confirmation dialogue backdrop ("Delete 'X' and all its documents?")
+- "New Collection" button → inline create row in table footer
+- Wired to existing `PUT /api/collections/:id` and `DELETE /api/collections/:id`
+- Wired LanceDB vector cleanup into collection delete (`deleteByCollection`)
+- `deleteCollection` service now async, route handler updated to `await`
+- Custom events for cross-module sync: `collections-changed` (page ↔ sidebar), `page-changed` (router → page)
+- Sidebar-right stays focused: quick-switch collections, upload files, view documents
+- Right sidebar listens for `collections-changed` and re-fetches automatically
+- New CSS file: `collections-page.css` (table, inline rename, create row, empty state, dialog)
+
+## Story 11: Document Delete Confirmation
+**Commit:** feat: Add confirmation prompt before document deletion
+
+- Reusable confirm dialogue module (`confirm-dialogue.js`), shared with Story 10
+- Show document name in prompt: "Delete report.pdf?"
+- Confirm / Cancel buttons, styled consistently with app theme
+- Wire LanceDB vector cleanup into individual document delete (known gap from Story 7)
+- Replace current instant-delete with confirmation flow
+
+## Story 12: RAG Chat Page — UI
+**Commit:** feat: Add RAG chat interface with stats display
+
+- `public/css/rag-page.css` — stats cards, chat container, message bubbles, input bar
+- Stats row: Documents, Chunks, Embeddings counts (fetched from API)
+- Chat message rendering: user bubbles (right-aligned) and assistant bubbles (left-aligned)
+- Source references section below assistant messages
+- Loading/typing indicator during generation
+- Auto-scroll to latest message
+- `public/js/rag-page.js` — chat UI logic
+- API endpoint: `GET /api/rag/stats/:collectionId`
+
+## Story 13: RAG Chat — Query, Retrieval & Generation
+**Commit:** feat: Add RAG query flow with retrieval and LLM generation
+
+- `POST /api/rag/query` — accepts `{ query, collectionId }`
+- `services/rag-query-service.js` — orchestrate: embed query → vector search → build prompt → LLM call
+- Prompt template: system context + retrieved chunks + user question
+- Ollama chat completion (e.g. `llama3.2` or configurable model)
+- Response includes generated answer + source references (document name, chunk excerpt)
+- Wire frontend chat input to POST endpoint
+- Display sources as clickable references below the answer
+
+
+# Stories
+
+## Story 1: Project Scaffolding & Dev Environment
+**Commit:** Initial scaffolding
+
+- Express 5 server with static file serving (`public/`)
+- ES module configuration (`"type": "module"`)
+- CORS middleware
+- `npm run dev` with `--watch` for auto-restart
+- Frontend hello-world: `ui-orchestrator.js` → `api-client.js` → `GET /api/hello`
+- README, ROADMAP, LICENSE, .gitignore
+
+## Story 2: Three-Panel Layout & Theming
+**Commit:** feat: Add three-panel layout with mint theme and component CSS
+
+- Three-panel CSS Grid layout: left sidebar (260px), main content (flex), right sidebar (304px)
+- Mint theme via CSS custom properties (backgrounds, accents, text, borders, spacing, radii)
+- Component CSS files: `sidebar-left.css`, `sidebar-right.css`, `main-content.css`, `footer.css`
+- Left sidebar: logo/branding, nav links (Home, Dashboard, RAG Chat), settings + collapse footer
+- Right sidebar: header, upload button, document list structure
+- Collapsed sidebar CSS (visual rules only, JS toggle in later story)
+- Footer with status indicator and version display
+- CSS reset and base typography
+- JS files moved to `public/js/` directory
+
+---
+
+## Tech Debt
+
+### TD-1: Audit route parameter handling across all route files
+**Priority:** Low
+**Context:** During Story 10, a bug surfaced in the DELETE `/api/collections/:id` handler where destructured `req.params` was passed incorrectly to a downstream service. Fixed by using `req.params.id` directly.
+
+**Scope:**
+- Review all handlers in `collection-routes.js`, `document-routes.js`, `embedding-routes.js`, `model-routes.js`
+- Ensure `req.params.*` and `req.body.*` values are accessed inline rather than destructured into intermediate variables where unnecessary
+- Confirm each parameter reaches its service function as the expected primitive type (string, number)
+- Add guard clauses for missing or malformed params where absent (e.g. `embedding-routes.js` POST has no check for missing `documentId`)
+- Standardise the pattern: validate early, return 400 with a clear message, then call the service
+
+### TD-2: Store timestamps as UTC with timezone indicator
+**Priority:** Low
+**Context:** SQLite `datetime('now')` produces strings like `"2025-02-15 14:30:00"` with no timezone suffix. The frontend has to guess UTC by appending `"Z"`, which broke when client-generated ISO strings (which already include `Z`) were passed through the same `formatDate` function. A defensive check was added, but the root cause remains in the schema.
+
+**Scope:**
+- Update migration default expressions to use `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')` so all stored timestamps are unambiguous ISO 8601 with `Z` suffix
+- Audit all tables: `collections.created_at`, `collections.updated_at`, `documents.created_at`, `chunks.created_at`
+- Simplify `formatDate` on the frontend — remove the conditional `Z` append once all timestamps include it
+- Consider returning `created_at` from the `addCollection` service so the frontend doesn't need to fabricate it

--- a/design.md
+++ b/design.md
@@ -1,0 +1,97 @@
+# Frontend
+
+## Prompt
+I'm building a vanilla JS AI Lab website. The frontend is composed of Javascript, HTML and CSS. 
+You have access to all libraries applicable to this tech stack. I want to create the home page 
+based off the Skeleton layout attached. The colour palette I want must be neutral, light themed
+and if any colour is added it must be light pastel.  The web app is split into 3 sections.
+
+The left section provide the menu context and has a header AI Lab. This section is adjustable 
+and can be hidden to just show icons. The right section has the same adjustable and hidden 
+qualities. The right side allows users to add folders and the folders will be listed below. 
+The centre section skeleton page shows the landing page and will display whatever menu context
+the user has selected
+
+Show the collapsed sidebar view
+
+Keep the design and layout exactly as is but generate 3 variation with different colour palettes
+
+## Stitch - with Google
+Model Selected - 3 Flash
+
+### Themes/ Colour Palettes
+
+1. Mint & Sage (Green) Palette
+   This theme uses organic, soft greens to create a calming research environment.
+****
+/* Mint Theme Styles */
+.theme-mint {
+--bg-main: #FBFDFB;
+--bg-sidebar: #F1F8F4;
+--accent-primary: #81C784; /* Sage Green */
+--accent-soft: #E0F2F1;    /* Mint Tint */
+--text-main: #2D3436;
+--text-muted: #636E72;
+--border-color: #E8F5E9;
+}
+
+.theme-mint .sidebar {
+background-color: var(--bg-sidebar);
+border-right: 1px solid var(--border-color);
+}
+
+.theme-mint .btn-primary {
+background-color: var(--accent-primary);
+color: white;
+border: none;
+border-radius: 8px;
+padding: 10px 20px;
+transition: background 0.3s ease;
+}
+
+.theme-mint .btn-primary:hover {
+background-color: #66BB6A;
+}
+
+.theme-mint .folder-icon {
+color: var(--accent-primary);
+}
+```
+
+2. Azure & Sky (Blue) Palette
+   This is a more traditional, clean "Lab" look using light blue tones.
+
+```
+/* Azure Blue Theme Styles */
+.theme-blue {
+--bg-main: #FFFFFF;
+--bg-sidebar: #F5F9FF;
+--accent-primary: #4A90E2; /* Azure Blue */
+--accent-soft: #E1F5FE;    /* Sky Blue */
+--text-main: #2C3E50;
+--text-muted: #7F8C8D;
+--border-color: #E3F2FD;
+}
+
+.theme-blue .sidebar {
+background-color: var(--bg-sidebar);
+border-right: 1px solid var(--border-color);
+}
+
+.theme-blue .btn-primary {
+background-color: var(--accent-primary);
+color: white;
+border: none;
+border-radius: 8px;
+padding: 10px 20px;
+transition: background 0.3s ease;
+}
+
+.theme-blue .btn-primary:hover {
+background-color: #357ABD;
+}
+
+.theme-blue .folder-icon {
+color: var(--accent-primary);
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vanilla-ai-lab",
+  "name": "vanilla-rag-lab",
   "version": "1.0.0",
-  "description": "AI lab to build and visualise AI systems",
+  "description": "RAG lab to build and visualise RAG systems",
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
@@ -13,16 +13,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maximpike/vanilla-ai-lab.git"
+    "url": "git+https://github.com/maximpike/vanilla-rag-lab.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",
   "bugs": {
-    "url": "https://github.com/maximpike/vanilla-ai-lab/issues"
+    "url": "https://github.com/maximpike/vanilla-rag-lab/issues"
   },
-  "homepage": "https://github.com/maximpike/vanilla-ai-lab#readme",
+  "homepage": "https://github.com/maximpike/vanilla-rag-lab#readme",
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",
     "better-sqlite3": "^12.6.2",

--- a/services/rag-query-service.js
+++ b/services/rag-query-service.js
@@ -84,9 +84,11 @@ const buildSystemPrompt = (chunks) => {
         .join("\n\n");
 
     return `
-        You are a helpful research assistant. Answer the user's question using ONLY the context provided below. If the context does not contain enough information to answer, say so honestly — do not make things up.
+        You are a helpful research assistant. Answer the user's question using ONLY the context provided below. 
+        If the context does not contain enough information to answer, say so honestly — do not make things up.
     
-        When referencing information, mention which source it came from using the document name in parentheses, e.g. "(report.pdf)".
+        When referencing information, mention which source it came from using the document name in parentheses,
+        e.g. "(report.pdf)".
     
         Keep your answers clear, concise, and well-structured.
     


### PR DESCRIPTION
## Summary

Documentation overhaul and project rebrand (`vanilla-ai-lab` → `vanilla-rag-lab`). No runtime behaviour changes beyond a whitespace reflow of a prompt string.

- Rewrite ROADMAP into a phase-based structure that points to GitHub Issues
- Expand MODULES.md with entry-point, client, UI, and service docs (Routes and Testing sections still stubbed for a later pass)
- Rename project `vanilla-ai-lab` → `vanilla-rag-lab` in package.json
- Add GitHub issue templates (bug/feature/tech-debt) and a branching-strategy placeholder
- Add design.md capturing the frontend prompt and colour palettes
- Mark STORIES.md as historical, pending migration to Issues and deletion
- Add NEXT_ACTIONS.md handoff doc and .env.example for fresh clones
- Ignore .DS_Store and other macOS cruft

## Follow-ups (tracked in NEXT_ACTIONS.md)

- MODULES.md Routes + Testing sections still to be written
- `.github/BRANCHING-STRATEGY.md` is an empty placeholder
- Propagate the rebrand to README.md (still titled "Vanilla AI Lab")
- Rename the GitHub repo so the new package.json URL resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)